### PR TITLE
feat: add core to grid plan widget

### DIFF
--- a/src/pymmcore_widgets/mda/ICONS/bottom.svg
+++ b/src/pymmcore_widgets/mda/ICONS/bottom.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="bottom.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="22.06519"
+     inkscape:cx="7.9310444"
+     inkscape:cy="12.961593"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="2.9997597"
+     inkscape:label="right" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="3.0015535"
+     y="16.971045"
+     inkscape:label="bottom" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/bottom_left.svg
+++ b/src/pymmcore_widgets/mda/ICONS/bottom_left.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="bottom_left.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="34.339718"
+     inkscape:cx="11.910407"
+     inkscape:cy="11.065903"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="2.9729412"
+     inkscape:label="left" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="3.0081577"
+     inkscape:label="right" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="2.9877651"
+     y="16.984833"
+     inkscape:label="bottom" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/bottom_right.svg
+++ b/src/pymmcore_widgets/mda/ICONS/bottom_right.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="bottom_right.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="34.339718"
+     inkscape:cx="11.910407"
+     inkscape:cy="11.065903"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="3.0081577"
+     inkscape:label="right" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="2.9877651"
+     y="16.984833"
+     inkscape:label="bottom" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/left.svg
+++ b/src/pymmcore_widgets/mda/ICONS/left.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="left.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="22.06519"
+     inkscape:cx="7.9310444"
+     inkscape:cy="12.961593"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="2.9997597"
+     inkscape:label="right" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="3.0015535"
+     y="16.971045"
+     inkscape:label="bottom" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/right.svg
+++ b/src/pymmcore_widgets/mda/ICONS/right.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="right.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="22.06519"
+     inkscape:cx="7.9310444"
+     inkscape:cy="12.961593"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="2.9997597"
+     inkscape:label="right" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="3.0015535"
+     y="16.971045"
+     inkscape:label="bottom" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/top.svg
+++ b/src/pymmcore_widgets/mda/ICONS/top.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="top.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="22.06519"
+     inkscape:cx="7.9310444"
+     inkscape:cy="12.961593"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M 3,3 H 21 V 21 H 3 V 3 M 5,5 V 19 H 19 V 5 Z"
+     id="path1"
+     style="display:none" />
+  <path
+     d="M 4.988198,4.9888238 H 19.009266 V 19.019865 H 4.988198 V 4.9888238 M 6.5460939,6.5478285 V 17.46086 H 17.45137 V 6.5478284 Z"
+     id="path1-9"
+     style="display:none;stroke-width:0.779225" />
+  <rect
+     style="display:none;fill:#ffffff;stroke-width:0.338012"
+     id="rect9-2"
+     width="4.6148739"
+     height="2.1793642"
+     x="2.877759"
+     y="0.82610959"
+     ry="0.19255261" />
+  <rect
+     style="display:none;fill:#ffffff;stroke-width:0.342868"
+     id="rect10"
+     width="3.0285466"
+     height="5.1121454"
+     x="20.991459"
+     y="15.946057"
+     ry="0.17426696" />
+  <rect
+     style="display:none;fill:#ffffff;stroke-width:0.819543"
+     id="rect10-5"
+     width="5.4775095"
+     height="16.148903"
+     x="18.179834"
+     y="0.85667294"
+     ry="0.55049694" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="2.9997597"
+     inkscape:label="right" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="3.0015535"
+     y="16.971045"
+     inkscape:label="bottom" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/top_left.svg
+++ b/src/pymmcore_widgets/mda/ICONS/top_left.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="top_left.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="22.06519"
+     inkscape:cx="7.9310444"
+     inkscape:cy="12.961593"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="2.9997597"
+     inkscape:label="right" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="3.0015535"
+     y="16.971045"
+     inkscape:label="bottom" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/ICONS/top_right.svg
+++ b/src/pymmcore_widgets/mda/ICONS/top_right.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="top_right.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="34.339718"
+     inkscape:cx="11.910407"
+     inkscape:cy="11.065903"
+     inkscape:window-width="1728"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect20"
+     width="4"
+     height="18"
+     x="2.9921963"
+     y="3.0020618"
+     inkscape:label="left" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect20-8"
+     width="4"
+     height="18"
+     x="16.994165"
+     y="3.0081577"
+     inkscape:label="right" />
+  <rect
+     style="display:none;fill:#000000"
+     id="rect21"
+     width="18"
+     height="4"
+     x="2.9877651"
+     y="16.984833"
+     inkscape:label="bottom" />
+  <rect
+     style="display:inline;fill:#000000"
+     id="rect21-6"
+     width="18"
+     height="4"
+     x="2.9976473"
+     y="3.007935"
+     inkscape:label="top" />
+</svg>

--- a/src/pymmcore_widgets/mda/_core_grid.py
+++ b/src/pymmcore_widgets/mda/_core_grid.py
@@ -1,0 +1,62 @@
+from typing import cast
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtWidgets import (
+    QGridLayout,
+    QLayout,
+    QRadioButton,
+    QWidget,
+)
+
+from pymmcore_widgets.useq_widgets import GridPlanWidget
+
+from ._xy_bounds import CoreXYBoundsControl
+
+
+class CoreConnectedGridPlanWidget(GridPlanWidget):
+    def __init__(
+        self, mmcore: CMMCorePlus | None = None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._mmc = mmcore or CMMCorePlus.instance()
+
+        _layout = cast(QLayout, self.layout().itemAt(4))
+        # hide the widgets we don't need from the GridPlanWidget's GridFromEdges plan
+        self._edges_radiobtn: QRadioButton | None = None
+        self._hide_widgets(_layout)
+        # replace them with the CoreXYBoundsControl
+        _grid_layout = cast(QGridLayout, _layout.itemAt(1))
+        _grid_layout.setContentsMargins(0, 0, 0, 0)
+        self._core_xy_bounds = CoreXYBoundsControl(core=self._mmc)
+        self._core_xy_bounds.setEnabled(False)
+        _grid_layout.addWidget(self._core_xy_bounds, 0, 0, 1, 4)
+
+        # replace GridPlanWidget attributes with CoreXYBoundsControl attributes so we
+        # can use the same super() methods.
+        self.top = self._core_xy_bounds.top_edit._spin
+        self.left = self._core_xy_bounds.left_edit._spin
+        self.right = self._core_xy_bounds.right_edit._spin
+        self.bottom = self._core_xy_bounds.bottom_edit._spin
+
+        # connect
+        self.top.valueChanged.connect(self._on_change)
+        self.left.valueChanged.connect(self._on_change)
+        self.right.valueChanged.connect(self._on_change)
+        self.bottom.valueChanged.connect(self._on_change)
+
+    def _on_toggle(self, checked: bool) -> None:
+        self._core_xy_bounds.setEnabled(checked)
+
+    def _hide_widgets(self, layout: QLayout) -> None:
+        """Recursively hide all widgets in the GridPlanWidget GridFromEdges layout."""
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
+            wdg = item.widget()
+            if wdg is not None:
+                if isinstance(wdg, QRadioButton):
+                    self._edges_radiobtn = wdg
+                    self._edges_radiobtn.toggled.connect(self._on_toggle)
+                    continue
+                wdg.hide()
+            else:
+                self._hide_widgets(item)

--- a/src/pymmcore_widgets/mda/_core_grid.py
+++ b/src/pymmcore_widgets/mda/_core_grid.py
@@ -64,7 +64,7 @@ class CoreConnectedGridPlanWidget(GridPlanWidget):
 
     def _on_change(self) -> None:
         # TODO: owerriding this for now because there is some issue in the rendering of
-        # the GridFromEdges. Will work on it in the future
+        # the GridFromEdges.
 
         val = self.value()
 
@@ -86,6 +86,7 @@ class CoreConnectedGridPlanWidget(GridPlanWidget):
 
     def value(self) -> useq.GridFromEdges | useq.GridRowsColumns | useq.GridWidthHeight:
         value = super().value()
+
         if isinstance(value, useq.GridWidthHeight):
             # convert from mm to um
             value = value.replace(width=value.width * 1000, height=value.height * 1000)

--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -73,6 +73,7 @@ class MDAWidget(MDASequenceWidget):
         self._mmc.mda.events.sequenceStarted.connect(self._on_mda_started)
         self._mmc.mda.events.sequenceFinished.connect(self._on_mda_finished)
         self._mmc.events.channelGroupChanged.connect(self._update_channel_groups)
+        self._mmc.events.systemConfigurationLoaded.connect(self._update_channel_groups)
 
         self.destroyed.connect(self._disconnect)
 
@@ -91,8 +92,14 @@ class MDAWidget(MDASequenceWidget):
     # ------------------- private API ----------------------
 
     def _update_channel_groups(self) -> None:
-        ch = self._mmc.getChannelGroup()
-        self.channels.setChannelGroups({ch: self._mmc.getAvailableConfigs(ch)})
+        self.channels.setChannelGroups(
+            {
+                group_name: self._mmc.getAvailableConfigs(group_name)
+                for group_name in self._mmc.getAvailableConfigGroups()
+            }
+        )
+        if ch := self._mmc.getChannelGroup():
+            self.channels._group_combo.setCurrentText(ch)
 
     def _on_run_clicked(self) -> None:
         """Run the MDA sequence experiment."""

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -183,21 +183,18 @@ class GridPlanWidget(QWidget):
     def _on_change(self) -> None:
         val = self.value()
 
-        if val is None:
-            return
-
-        if isinstance(val, useq.GridRowsColumns):
+        if val is not None:  # temporary
             draw_grid = val.replace(relative_to="top_left")
-            draw_grid.fov_height = 1 / ((val.rows - 1) or 1)
-            draw_grid.fov_width = 1 / ((val.columns - 1) or 1)
+            if isinstance(val, useq.GridRowsColumns):
+                draw_grid.fov_height = 1 / ((val.rows - 1) or 1)
+                draw_grid.fov_width = 1 / ((val.columns - 1) or 1)
+            if isinstance(val, useq.GridFromEdges):
+                draw_grid.fov_height = 1 / ((val.bottom - val.top) or 1)
+                draw_grid.fov_width = 1 / ((val.right - val.left) or 1)
             self._grid_img.grid = draw_grid
-        else:
-            # TODO: draw also when GridWidthHeight and GridFromEdges
-            self._grid_img.grid = None
+            self._grid_img.update()
 
-        self._grid_img.update()
-
-        self.valueChanged.emit(val)
+            self.valueChanged.emit(val)
 
     def mode(self) -> Mode:
         return self._mode

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -183,18 +183,21 @@ class GridPlanWidget(QWidget):
     def _on_change(self) -> None:
         val = self.value()
 
-        if val is not None:  # temporary
-            draw_grid = val.replace(relative_to="top_left")
-            if isinstance(val, useq.GridRowsColumns):
-                draw_grid.fov_height = 1 / ((val.rows - 1) or 1)
-                draw_grid.fov_width = 1 / ((val.columns - 1) or 1)
-            if isinstance(val, useq.GridFromEdges):
-                draw_grid.fov_height = 1 / ((val.bottom - val.top) or 1)
-                draw_grid.fov_width = 1 / ((val.right - val.left) or 1)
-            self._grid_img.grid = draw_grid
-            self._grid_img.update()
+        if val is None:
+            return
 
-            self.valueChanged.emit(val)
+        if isinstance(val, useq.GridRowsColumns):
+            draw_grid = val.replace(relative_to="top_left")
+            draw_grid.fov_height = 1 / ((val.rows - 1) or 1)
+            draw_grid.fov_width = 1 / ((val.columns - 1) or 1)
+            self._grid_img.grid = draw_grid
+        else:
+            # TODO: draw also when GridWidthHeight and GridFromEdges
+            self._grid_img.grid = None
+
+        self._grid_img.update()
+
+        self.valueChanged.emit(val)
 
     def mode(self) -> Mode:
         return self._mode
@@ -242,6 +245,7 @@ class GridPlanWidget(QWidget):
             "fov_width": self._fov_width,
             "fov_height": self._fov_height,
         }
+
         if self._mode == Mode.NUMBER:
             return useq.GridRowsColumns(
                 rows=self.rows.value(),

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -65,6 +65,7 @@ class MDATabs(CheckableTabWidget):
         *,
         position_wdg: PositionTable | None = None,
         z_wdg: ZPlanWidget | None = None,
+        grid_wdg: GridPlanWidget | None = None,
     ) -> None:
         super().__init__(parent)
         # self.setMovable(True)
@@ -72,7 +73,7 @@ class MDATabs(CheckableTabWidget):
 
         self.time_plan = TimePlanWidget(1)
         self.stage_positions = position_wdg or PositionTable(1)
-        self.grid_plan = GridPlanWidget()
+        self.grid_plan = grid_wdg or GridPlanWidget()
         self.z_plan = z_wdg or ZPlanWidget()
         self.channels = ChannelTable(1)
 
@@ -169,12 +170,15 @@ class MDASequenceWidget(QWidget):
         *,
         position_wdg: PositionTable | None = None,
         z_wdg: ZPlanWidget | None = None,
+        grid_wdg: GridPlanWidget | None = None,
     ) -> None:
         super().__init__(parent)
 
         # -------------- Main MDA Axis Widgets --------------
 
-        self.tab_wdg = MDATabs(position_wdg=position_wdg, z_wdg=z_wdg)
+        self.tab_wdg = MDATabs(
+            position_wdg=position_wdg, z_wdg=z_wdg, grid_wdg=grid_wdg
+        )
 
         self.axis_order = QComboBox()
         self.axis_order.setToolTip("Slowest to fastest axis order.")


### PR DESCRIPTION
connecting the core to the `GridPlanWidget`.

still have to understand how to paint the `GridWidthHeight` and `GridFromEdges` but I think this can be a good start.

I also modified the `"go"` icon for the `CoreConnectedZPlanWidgert` to make it similar to this `CoreConnectedGridPlanWidget` .

no tests yet.

---
<img width="492" alt="Screenshot 2023-09-15 at 5 48 31 PM" src="https://github.com/tlambert03/pymmcore-widgets/assets/70725613/b6a6938a-158e-4c8b-8cf3-798bbe7e6077">

<img width="492" alt="Screenshot 2023-09-15 at 5 48 37 PM" src="https://github.com/tlambert03/pymmcore-widgets/assets/70725613/f4ade32a-6023-4d8f-930a-afc5ac3abbaa">

---

<img width="579" alt="Screenshot 2023-09-15 at 5 40 41 PM" src="https://github.com/tlambert03/pymmcore-widgets/assets/70725613/a3e95e6e-d133-4a0b-95a4-d03c0349f617">

<img width="582" alt="Screenshot 2023-09-15 at 5 45 44 PM" src="https://github.com/tlambert03/pymmcore-widgets/assets/70725613/68ba039d-11f1-445a-9348-976a8a6bbd8a">
