### PR TITLE
feat: implement nullable FloatColumn and update PositionTable for absolute grid plans

### DIFF
--- a/src/pymmcore_widgets/mda/_core_mda.py
+++ b/src/pymmcore_widgets/mda/_core_mda.py
@@ -189,7 +189,11 @@ class MDAWidget(MDASequenceWidget):
 
         # if there are no stage positions, use the current stage position
         if not val.stage_positions:
-            replace["stage_positions"] = (self._get_current_stage_position(),)
+            pos = self._get_current_stage_position()
+            # clear x/y if using an absolute global grid (they're meaningless)
+            if val.grid_plan is not None and not val.grid_plan.is_relative:
+                pos = pos.replace(x=None, y=None)
+            replace["stage_positions"] = (pos,)
             # if "p" is not in the axis order, we need to add it or the position will
             # not be in the event
             if "p" not in val.axis_order:

--- a/src/pymmcore_widgets/mda/_core_positions.py
+++ b/src/pymmcore_widgets/mda/_core_positions.py
@@ -441,6 +441,14 @@ class CoreConnectedPositionTable(PositionTable):
         self._mmc.waitForSystem()
         _perform_full_focus()
 
+    def _update_row_xy_enabled(self, row: int, seq: MDASequence | None) -> None:
+        """Also disable the XY button when an absolute grid is set."""
+        super()._update_row_xy_enabled(row, seq)
+        table = self.table()
+        xy_btn_col = table.indexOf(self._xy_btn_col)
+        if xy_btn := table.cellWidget(row, xy_btn_col):
+            xy_btn.setEnabled(not self._has_absolute_grid(seq))
+
     def _on_include_z_toggled(self, checked: bool) -> None:
         z_btn_col = self.table().indexOf(self._z_btn_col)
         self.table().setColumnHidden(z_btn_col, not checked)

--- a/src/pymmcore_widgets/useq_widgets/_column_info.py
+++ b/src/pymmcore_widgets/useq_widgets/_column_info.py
@@ -247,7 +247,43 @@ class TableSpinBox(_TableSpinboxMixin, QSpinBox):
 
 
 class TableDoubleSpinBox(_TableSpinboxMixin, QDoubleSpinBox):
-    pass
+    """A QDoubleSpinBox for table cells, with optional nullable support.
+
+    When nullable, the spinbox can represent None (shows blank). A sentinel
+    value one step below the real minimum is used internally.
+    """
+
+    _nullable: bool = False
+
+    def setNullable(self, nullable: bool) -> None:
+        """Enable or disable nullable mode."""
+        self._nullable = nullable
+        if nullable:
+            self.setSpecialValueText("None")
+            # adjust current minimum to add sentinel, then set value to sentinel
+            self.setMinimum(self.minimum())
+            super().setValue(self.minimum())
+
+    def _sentinel(self) -> float:
+        return float(self.minimum())
+
+    def value(self) -> float | None:
+        if self._nullable and super().value() == self._sentinel():
+            return None
+        return float(super().value())
+
+    def setValue(self, value: float | None) -> None:
+        if value is None and self._nullable:
+            super().setValue(self._sentinel())
+        else:
+            super().setValue(value)
+
+    def setMinimum(self, minimum: float) -> None:
+        if self._nullable:
+            # reserve one extra step below the real minimum as the sentinel
+            super().setMinimum(minimum - 1)
+        else:
+            super().setMinimum(minimum)
 
 
 TableIntWidget = WdgGetSet(
@@ -296,6 +332,27 @@ class IntColumn(_RangeColumn):
 @dataclass(frozen=True)
 class FloatColumn(_RangeColumn):
     data_type: WdgGetSet = TableFloatWidget
+    nullable: bool = False
+
+    def _init_widget(self) -> TableDoubleSpinBox:
+        wdg: TableDoubleSpinBox = self.data_type.widget()
+        # set min/max/decimals before enabling nullable,
+        # so the sentinel is based on the correct minimum
+        if self.minimum is not None:
+            wdg.setMinimum(self.minimum)
+        if self.maximum is not None:
+            wdg.setMaximum(self.maximum)
+        if self.decimals is not None:
+            wdg.setDecimals(self.decimals)
+        if self.nullable:
+            wdg.setNullable(True)
+        return wdg
+
+    def set_cell_data(
+        self, table: QTableWidget, row: int, col: int, value: Any
+    ) -> None:
+        if wdg := table.cellWidget(row, col):
+            self.data_type.setter(cast("TableDoubleSpinBox", wdg), value)
 
 
 # ########################  Timepoints  ################################

--- a/src/pymmcore_widgets/useq_widgets/_grid.py
+++ b/src/pymmcore_widgets/useq_widgets/_grid.py
@@ -310,6 +310,26 @@ class GridPlanWidget(QScrollArea):
         """Return the current field of view height."""
         return self._fov_height
 
+    def setAbsoluteModesEnabled(self, enabled: bool) -> None:
+        """Enable or disable absolute grid modes (Bounds, Polygon).
+
+        When disabled, a tooltip explains why.  If the current mode is absolute,
+        it is switched to the default relative mode (Fields of View).
+        """
+        tip = (
+            ""
+            if enabled
+            else "Absolute grid modes are unavailable when stage positions are set."
+        )
+        self._mode_bounds_radio.setEnabled(enabled)
+        self._mode_bounds_radio.setToolTip(tip)
+        self._mode_polygon_radio.setEnabled(enabled)
+        self._mode_polygon_radio.setToolTip(tip)
+
+        # if currently on an absolute mode, switch to relative
+        if not enabled and self._mode in (Mode.BOUNDS, Mode.POLYGON):
+            self._mode_number_radio.setChecked(True)
+
     # ------------------------- Private API -------------------------
 
     def _on_change(self) -> None:

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -133,9 +133,11 @@ class MDATabs(CheckableTabWidget):
         # validation warnings.
         if grid_plan is not None and not grid_plan.is_relative and positions:
             positions = tuple(
-                pos.replace(x=None, y=None)
-                if pos.x is not None or pos.y is not None
-                else pos
+                (
+                    pos.replace(x=None, y=None)
+                    if pos.x is not None or pos.y is not None
+                    else pos
+                )
                 for pos in positions
             )
 

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
     QSizePolicy,
+    QTabBar,
     QVBoxLayout,
     QWidget,
 )
@@ -348,8 +349,10 @@ class MDASequenceWidget(QWidget):
         self.channels.valueChanged.connect(self.valueChanged)
         self.time_plan.valueChanged.connect(self.valueChanged)
         self.stage_positions.valueChanged.connect(self.valueChanged)
+        self.stage_positions.valueChanged.connect(self._update_grid_absolute_modes)
         self.z_plan.valueChanged.connect(self._validate_af_with_z_plan)
         self.grid_plan.valueChanged.connect(self.valueChanged)
+        self.grid_plan.valueChanged.connect(self._update_position_tab_checkable)
         self.tab_wdg.tabChecked.connect(self._on_tab_checked)
         self.axis_order.currentTextChanged.connect(self.valueChanged)
         self.valueChanged.connect(self._update_time_estimate)
@@ -562,7 +565,46 @@ class MDASequenceWidget(QWidget):
             else:
                 self._enable_af(True)
 
+        if tab_idx == self.tab_wdg.indexOf(self.stage_positions):
+            self._update_grid_absolute_modes()
+
+        if tab_idx in (
+            self.tab_wdg.indexOf(self.grid_plan),
+            self.tab_wdg.indexOf(self.stage_positions),
+        ):
+            self._update_position_tab_checkable()
+
         self._update_available_axis_orders()
+
+    def _has_global_absolute_grid(self) -> bool:
+        """Return True if the global grid tab is checked with an absolute grid."""
+        return bool(
+            self.tab_wdg.isChecked(self.grid_plan)
+            and not self.grid_plan.value().is_relative
+        )
+
+    def _update_grid_absolute_modes(self) -> None:
+        """Disable absolute grid modes when positions are present."""
+        has_positions = (
+            self.tab_wdg.isChecked(self.stage_positions)
+            and self.stage_positions.table().rowCount() > 0
+        )
+        self.grid_plan.setAbsoluteModesEnabled(not has_positions)
+
+    def _update_position_tab_checkable(self) -> None:
+        """Disable the position tab checkbox when a global absolute grid is active."""
+        disabled = self._has_global_absolute_grid()
+        pos_idx = self.tab_wdg.indexOf(self.stage_positions)
+        if not (tab_bar := self.tab_wdg.tabBar()):
+            return  # pragma: no cover
+        cbox = tab_bar.tabButton(pos_idx, QTabBar.ButtonPosition.LeftSide)
+        if cbox:
+            cbox.setEnabled(not disabled)
+            cbox.setToolTip(
+                "Cannot use stage positions with a global absolute grid plan."
+                if disabled
+                else ""
+            )
 
     def _on_af_toggled(self) -> None:
         # if the 'af_per_position' checkbox in the PositionTable is checked, set checked

--- a/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
+++ b/src/pymmcore_widgets/useq_widgets/_mda_sequence.py
@@ -27,7 +27,11 @@ from pymmcore_widgets._humanize import humanize_time
 from pymmcore_widgets.useq_widgets._channels import ChannelTable
 from pymmcore_widgets.useq_widgets._checkable_tabwidget_widget import CheckableTabWidget
 from pymmcore_widgets.useq_widgets._grid import GridPlanWidget
-from pymmcore_widgets.useq_widgets._positions import AF_PER_POS_TOOLTIP, PositionTable
+from pymmcore_widgets.useq_widgets._positions import (
+    AF_PER_POS_TOOLTIP,
+    MDAButton,
+    PositionTable,
+)
 from pymmcore_widgets.useq_widgets._time import TimePlanWidget
 from pymmcore_widgets.useq_widgets._z import Mode, ZPlanWidget
 
@@ -446,9 +450,14 @@ class MDASequenceWidget(QWidget):
         axis_text = "".join(x for x in value.axis_order if x in self.tab_wdg.usedAxes())
         self.axis_order.setCurrentText(axis_text)
 
+        # Enforce grid/position constraints.  During setValue, signals fire in
+        # an order that can leave conflicting state (e.g. absolute grid + checked
+        # positions tab).  Detect and resolve here.
+        self._enforce_grid_position_constraints()
+
     def save(self, file: str | Path | None = None) -> None:
         """Save the current [`useq.MDASequence`][] to a file."""
-        if not isinstance(file, (str, Path)):
+        if not isinstance(file, str | Path):
             file, _ = QFileDialog.getSaveFileName(
                 self,
                 "Save MDASequence and filename.",
@@ -476,7 +485,7 @@ class MDASequenceWidget(QWidget):
 
     def load(self, file: str | Path | None = None) -> None:
         """Load a [`useq.MDASequence`][] from a file."""
-        if not isinstance(file, (str, Path)):
+        if not isinstance(file, str | Path):
             file, _ = QFileDialog.getOpenFileName(
                 self,
                 "Select an MDAsequence file.",
@@ -591,20 +600,63 @@ class MDASequenceWidget(QWidget):
         )
         self.grid_plan.setAbsoluteModesEnabled(not has_positions)
 
+    def _enforce_grid_position_constraints(self) -> None:
+        """Fix up state after setValue if both positions and absolute grid are set.
+
+        The global absolute grid is moved into each position's sub-sequence
+        (only those that don't already have a grid plan).  The global grid tab
+        is then unchecked.  x/y disabling is handled automatically by
+        `_update_row_xy_enabled` when each sub-sequence is set.
+        """
+        has_abs_grid = (
+            self.tab_wdg.isChecked(self.grid_plan)
+            and not self.grid_plan.value().is_relative
+        )
+        if (
+            not has_abs_grid
+            or not self.tab_wdg.isChecked(self.stage_positions)
+            or self.stage_positions.table().rowCount() == 0
+        ):
+            self._update_grid_absolute_modes()
+            self._update_position_tab_checkable()
+            return
+
+        # Move the global grid into each position that lacks its own grid plan.
+        grid_plan = self.grid_plan.value()
+        grid_seq = useq.MDASequence(grid_plan=grid_plan)
+        table = self.stage_positions.table()
+        seq_col = table.indexOf(self.stage_positions.SEQ)
+        for row in range(table.rowCount()):
+            btn = table.cellWidget(row, seq_col)
+            if isinstance(btn, MDAButton):
+                existing = btn.value()
+                if existing and existing != NULL_SEQUENCE:
+                    # Only add the grid if the sub-sequence has no grid plan.
+                    if existing.grid_plan is None:
+                        btn.setValue(existing.replace(grid_plan=grid_plan))
+                else:
+                    btn.setValue(grid_seq)
+        self.tab_wdg.setChecked(self.grid_plan, False)
+
+        self._update_grid_absolute_modes()
+        self._update_position_tab_checkable()
+
     def _update_position_tab_checkable(self) -> None:
         """Disable the position tab checkbox when a global absolute grid is active."""
         disabled = self._has_global_absolute_grid()
         pos_idx = self.tab_wdg.indexOf(self.stage_positions)
+        tip = (
+            "Cannot use stage positions with a global absolute grid plan."
+            if disabled
+            else ""
+        )
+        self.tab_wdg.setTabToolTip(pos_idx, tip)
         if not (tab_bar := self.tab_wdg.tabBar()):
             return  # pragma: no cover
         cbox = tab_bar.tabButton(pos_idx, QTabBar.ButtonPosition.LeftSide)
         if cbox:
             cbox.setEnabled(not disabled)
-            cbox.setToolTip(
-                "Cannot use stage positions with a global absolute grid plan."
-                if disabled
-                else ""
-            )
+            cbox.setToolTip(tip)
 
     def _on_af_toggled(self) -> None:
         # if the 'af_per_position' checkbox in the PositionTable is checked, set checked

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -375,14 +375,6 @@ class PositionTable(DataTableWidget):
                 self._update_row_xy_enabled(row, btn.value())
                 break
 
-    def _has_absolute_grid(self, seq: useq.MDASequence | None) -> bool:
-        """Return True if the sequence has an absolute (non-relative) grid plan."""
-        return (
-            seq is not None
-            and seq.grid_plan is not None
-            and not seq.grid_plan.is_relative
-        )
-
     def _update_row_xy_enabled(self, row: int, seq: useq.MDASequence | None) -> None:
         """Disable x/y and show first grid position if absolute grid, else re-enable."""
         table = self.table()
@@ -390,7 +382,7 @@ class PositionTable(DataTableWidget):
         y_col = table.indexOf(self.Y)
         disabled = self._has_absolute_grid(seq)
         if disabled:
-            xy = self._first_grid_xy(seq.grid_plan)  # type: ignore [union-attr]
+            xy = self._get_grid_xy(seq)
             self.X.set_cell_data(table, row, x_col, xy[0] if xy else None)
             self.Y.set_cell_data(table, row, y_col, xy[1] if xy else None)
         tip = (
@@ -405,14 +397,23 @@ class PositionTable(DataTableWidget):
             y_wdg.setEnabled(not disabled)
             y_wdg.setToolTip(tip)
 
-    @staticmethod
-    def _first_grid_xy(grid_plan: object) -> tuple[float, float] | None:
-        """Return (x, y) of the first position in a grid plan, or None."""
-        try:
-            first = next(iter(grid_plan))  # type: ignore [call-overload]
-            return (first.x, first.y)
-        except Exception:
-            return None
+    def _has_absolute_grid(self, seq: useq.MDASequence | None) -> bool:
+        """Return True if the sequence has an absolute (non-relative) grid plan."""
+        return (
+            seq is not None
+            and seq.grid_plan is not None
+            and not seq.grid_plan.is_relative
+        )
+
+    def _get_grid_xy(
+        self, seq: useq.MDASequence | None
+    ) -> tuple[float | None, float | None]:
+        """Get the x/y position of the first position in the grid plan."""
+        if seq is not None and seq.grid_plan is not None:
+            first_pos = next(iter(seq.grid_plan), None)
+            if first_pos is not None:
+                return first_pos.x, first_pos.y
+        return None, None
 
     # ------------------------- Private API -------------------------
 

--- a/src/pymmcore_widgets/useq_widgets/_positions.py
+++ b/src/pymmcore_widgets/useq_widgets/_positions.py
@@ -161,15 +161,23 @@ class SubSeqColumn(WidgetColumn):
 class PositionTable(DataTableWidget):
     """Table to edit a list of [useq.Position](https://pymmcore-plus.github.io/useq-schema/schema/axes/#useq.Position)."""
 
+    # fmt: off
     NAME = TextColumn(key="name", default=None, is_row_selector=True)
-    X = FloatColumn(key="x", header="X [µm]", default=0.0, maximum=MAX, minimum=-MAX)
-    Y = FloatColumn(key="y", header="Y [µm]", default=0.0, maximum=MAX, minimum=-MAX)
-    Z = FloatColumn(key="z", header="Z [µm]", default=0.0, maximum=MAX, minimum=-MAX)
+    X = FloatColumn(key="x", header="X [µm]", default=None, maximum=MAX, minimum=-MAX, nullable=True)  # noqa: E501
+    Y = FloatColumn(key="y", header="Y [µm]", default=None, maximum=MAX, minimum=-MAX, nullable=True)  # noqa: E501
+    Z = FloatColumn(key="z", header="Z [µm]", default=None, maximum=MAX, minimum=-MAX, nullable=True)  # noqa: E501
     AF = FloatColumn(key="af", header="AF", default=0.0, maximum=MAX, minimum=-MAX)
     SEQ = SubSeqColumn(key="sequence", header="Sub-Sequence", default=None)
+    # fmt: on
 
     def __init__(self, rows: int = 0, parent: QWidget | None = None):
         super().__init__(rows, parent)
+
+        # when a sub-sequence changes, clear x/y if it has an absolute grid
+        self.table().model().rowsInserted.connect(self._connect_sub_seq)
+        # connect any rows that were created during super().__init__()
+        if (rows := self.table().rowCount()) > 0:
+            self._connect_sub_seq(None, 0, rows - 1)
 
         self.include_z = QCheckBox("Include Z")
         self.include_z.setChecked(True)
@@ -345,6 +353,66 @@ class PositionTable(DataTableWidget):
             self.setValue([useq.Position(**d) for d in data])
         except Exception as e:  # pragma: no cover
             raise ValueError(f"Failed to load MDASequence file: {src}") from e
+
+    def _connect_sub_seq(self, _parent: object, start: int, end: int) -> None:
+        """Connect MDAButton.valueChanged to _on_sub_seq_changed for new rows."""
+        table = self.table()
+        seq_col = table.indexOf(self.SEQ)
+        for row in range(start, end + 1):
+            wdg = table.cellWidget(row, seq_col)
+            if isinstance(wdg, MDAButton):
+                wdg.valueChanged.connect(self._on_sub_seq_changed)
+
+    def _on_sub_seq_changed(self) -> None:
+        """Update x/y state when a sub-sequence changes."""
+        btn = self.sender()
+        if not isinstance(btn, MDAButton):
+            return
+        table = self.table()
+        seq_col = table.indexOf(self.SEQ)
+        for row in range(table.rowCount()):
+            if table.cellWidget(row, seq_col) is btn:
+                self._update_row_xy_enabled(row, btn.value())
+                break
+
+    def _has_absolute_grid(self, seq: useq.MDASequence | None) -> bool:
+        """Return True if the sequence has an absolute (non-relative) grid plan."""
+        return (
+            seq is not None
+            and seq.grid_plan is not None
+            and not seq.grid_plan.is_relative
+        )
+
+    def _update_row_xy_enabled(self, row: int, seq: useq.MDASequence | None) -> None:
+        """Disable x/y and show first grid position if absolute grid, else re-enable."""
+        table = self.table()
+        x_col = table.indexOf(self.X)
+        y_col = table.indexOf(self.Y)
+        disabled = self._has_absolute_grid(seq)
+        if disabled:
+            xy = self._first_grid_xy(seq.grid_plan)  # type: ignore [union-attr]
+            self.X.set_cell_data(table, row, x_col, xy[0] if xy else None)
+            self.Y.set_cell_data(table, row, y_col, xy[1] if xy else None)
+        tip = (
+            "XY positions are defined by the absolute grid plan in the sub-sequence."
+            if disabled
+            else ""
+        )
+        if x_wdg := table.cellWidget(row, x_col):
+            x_wdg.setEnabled(not disabled)
+            x_wdg.setToolTip(tip)
+        if y_wdg := table.cellWidget(row, y_col):
+            y_wdg.setEnabled(not disabled)
+            y_wdg.setToolTip(tip)
+
+    @staticmethod
+    def _first_grid_xy(grid_plan: object) -> tuple[float, float] | None:
+        """Return (x, y) of the first position in a grid plan, or None."""
+        try:
+            first = next(iter(grid_plan))  # type: ignore [call-overload]
+            return (first.x, first.y)
+        except Exception:
+            return None
 
     # ------------------------- Private API -------------------------
 

--- a/tests/test_useq_core_widgets.py
+++ b/tests/test_useq_core_widgets.py
@@ -1052,6 +1052,39 @@ def test_grid_plan_subsequence_fov_update(
     assert sp.value()[0].sequence.grid_plan.fov_height == 75
 
 
+def test_core_position_table_absolute_grid_disables_xy_btn(qtbot: QtBot) -> None:
+    """Test that an absolute grid sub-sequence disables the XY button."""
+    wdg = MDAWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    pos_table = wdg.stage_positions
+    assert isinstance(pos_table, CoreConnectedPositionTable)
+
+    abs_grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
+    positions = [
+        useq.Position(z=0, sequence=useq.MDASequence(grid_plan=abs_grid)),
+        useq.Position(x=1, y=1, z=1),
+    ]
+    wdg.tab_wdg.setChecked(wdg.stage_positions, True)
+    pos_table.setValue(positions)
+
+    table = pos_table.table()
+    xy_btn_col = table.indexOf(pos_table._xy_btn_col)
+    x_col = table.indexOf(pos_table.X)
+    y_col = table.indexOf(pos_table.Y)
+
+    # row 0 has absolute grid: XY button and x/y cells should be disabled
+    assert not table.cellWidget(0, xy_btn_col).isEnabled()
+    assert not table.cellWidget(0, x_col).isEnabled()
+    assert not table.cellWidget(0, y_col).isEnabled()
+
+    # row 1 has no grid: XY button and x/y cells should be enabled
+    assert table.cellWidget(1, xy_btn_col).isEnabled()
+    assert table.cellWidget(1, x_col).isEnabled()
+    assert table.cellWidget(1, y_col).isEnabled()
+
+
 def test_sub_wdg_channel_tab(qtbot: QtBot, global_mmcore: CMMCorePlus) -> None:
     wdg = MDAWidget()
     qtbot.addWidget(wdg)

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -629,6 +629,213 @@ def test_autofocus_with_z_plans(qtbot: QtBot) -> None:
     assert wdg.stage_positions.af_per_position.isEnabled()
 
 
+def test_nullable_float_column(qtbot: QtBot) -> None:
+    """Test that nullable FloatColumn shows None and handles sentinel values."""
+    from pymmcore_widgets.useq_widgets._column_info import TableDoubleSpinBox
+
+    wdg = DataTableWidget()
+    qtbot.addWidget(wdg)
+    table = wdg.table()
+
+    col = FloatColumn(key="val", default=None, minimum=-100, maximum=100, nullable=True)
+    table.addColumn(col, position=-1)
+    table.setRowCount(1)
+
+    spin = table.cellWidget(0, table.indexOf(col))
+    assert isinstance(spin, TableDoubleSpinBox)
+
+    # default is None for nullable column
+    assert spin.value() is None
+    assert spin.text() == "None"
+
+    # setting a real value works
+    spin.setValue(42.0)
+    assert spin.value() == 42.0
+
+    # setting None goes back to sentinel
+    spin.setValue(None)
+    assert spin.value() is None
+
+    # set_cell_data with None works (no guard)
+    col.set_cell_data(table, 0, table.indexOf(col), 5.0)
+    assert spin.value() == 5.0
+    col.set_cell_data(table, 0, table.indexOf(col), None)
+    assert spin.value() is None
+
+
+def test_position_table_nullable_xy(qtbot: QtBot) -> None:
+    """Test that PositionTable x/y show None when positions have no x/y set."""
+    wdg = PositionTable()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    # set a position with only z
+    wdg.setValue([useq.Position(z=5.0)])
+    positions = wdg.value()
+    assert len(positions) == 1
+    assert positions[0].x is None
+    assert positions[0].y is None
+    assert positions[0].z == 5.0
+
+    # set a position with x, y, z
+    wdg.setValue([useq.Position(x=1.0, y=2.0, z=3.0)])
+    positions = wdg.value()
+    assert positions[0].x == 1.0
+    assert positions[0].y == 2.0
+
+
+def test_position_table_absolute_grid_disables_xy(qtbot: QtBot) -> None:
+    """Test that sub-sequence with absolute grid disables x/y and shows grid pos."""
+    wdg = PositionTable()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    abs_grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
+    # create position without x/y (as useq now warns if x/y set with absolute grid)
+    pos = useq.Position(
+        z=3.0,
+        sequence=useq.MDASequence(grid_plan=abs_grid),
+    )
+    wdg.setValue([pos])
+
+    table = wdg.table()
+    x_col = table.indexOf(wdg.X)
+    y_col = table.indexOf(wdg.Y)
+
+    # x/y widgets should be disabled
+    x_wdg = table.cellWidget(0, x_col)
+    y_wdg = table.cellWidget(0, y_col)
+    assert not x_wdg.isEnabled()
+    assert not y_wdg.isEnabled()
+
+    # x/y should show the first grid position
+    first_pos = next(iter(abs_grid))
+    assert x_wdg.value() == first_pos.x
+    assert y_wdg.value() == first_pos.y
+
+    # value() should clear x/y for absolute grid sub-sequence
+    positions = wdg.value()
+    assert positions[0].x is None
+    assert positions[0].y is None
+
+
+def test_position_table_relative_grid_keeps_xy(qtbot: QtBot) -> None:
+    """Test that sub-sequence with relative grid keeps x/y enabled."""
+    wdg = PositionTable()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    rel_grid = useq.GridRowsColumns(rows=2, columns=2)
+    pos = useq.Position(
+        x=50.0,
+        y=60.0,
+        z=3.0,
+        sequence=useq.MDASequence(grid_plan=rel_grid),
+    )
+    wdg.setValue([pos])
+
+    table = wdg.table()
+    x_col = table.indexOf(wdg.X)
+    y_col = table.indexOf(wdg.Y)
+
+    # x/y widgets should stay enabled for relative grid
+    assert table.cellWidget(0, x_col).isEnabled()
+    assert table.cellWidget(0, y_col).isEnabled()
+
+    # value() should keep x/y
+    positions = wdg.value()
+    assert positions[0].x == 50.0
+    assert positions[0].y == 60.0
+
+
+def test_position_table_sub_seq_change_toggles_xy(qtbot: QtBot) -> None:
+    """Test that changing sub-sequence toggles x/y enabled state."""
+    from pymmcore_widgets.useq_widgets._positions import MDAButton
+
+    wdg = PositionTable()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    wdg.table().setRowCount(1)
+    table = wdg.table()
+    seq_col = table.indexOf(wdg.SEQ)
+    x_col = table.indexOf(wdg.X)
+    y_col = table.indexOf(wdg.Y)
+
+    btn = table.cellWidget(0, seq_col)
+    assert isinstance(btn, MDAButton)
+
+    # initially x/y should be enabled
+    assert table.cellWidget(0, x_col).isEnabled()
+    assert table.cellWidget(0, y_col).isEnabled()
+
+    # set an absolute grid sub-sequence
+    abs_grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
+    btn.setValue(useq.MDASequence(grid_plan=abs_grid))
+
+    # x/y should now be disabled
+    assert not table.cellWidget(0, x_col).isEnabled()
+    assert not table.cellWidget(0, y_col).isEnabled()
+
+    # clear the sub-sequence
+    btn.setValue(None)
+
+    # x/y should be re-enabled
+    assert table.cellWidget(0, x_col).isEnabled()
+    assert table.cellWidget(0, y_col).isEnabled()
+
+
+def test_has_absolute_grid_helper(qtbot: QtBot) -> None:
+    """Test the _has_absolute_grid helper method."""
+    wdg = PositionTable()
+    qtbot.addWidget(wdg)
+
+    assert not wdg._has_absolute_grid(None)
+    assert not wdg._has_absolute_grid(useq.MDASequence())
+    assert not wdg._has_absolute_grid(
+        useq.MDASequence(grid_plan=useq.GridRowsColumns(rows=2, columns=2))
+    )
+    assert wdg._has_absolute_grid(
+        useq.MDASequence(grid_plan=useq.GridFromEdges(top=1, bottom=0, left=0, right=1))
+    )
+
+
+def test_first_grid_xy_helper() -> None:
+    """Test the _first_grid_xy static method."""
+    grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
+    result = PositionTable._first_grid_xy(grid)
+    assert result is not None
+    first = next(iter(grid))
+    assert result == (first.x, first.y)
+
+    # invalid input returns None
+    assert PositionTable._first_grid_xy(None) is None
+    assert PositionTable._first_grid_xy("not a grid") is None
+
+
+def test_mda_value_clears_xy_for_absolute_grid(qtbot: QtBot) -> None:
+    """Test that MDATabs.value() clears x/y when a global absolute grid is used."""
+    wdg = MDASequenceWidget()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    # set positions with x/y first (no grid yet)
+    pos_seq = useq.MDASequence(stage_positions=[useq.Position(x=50, y=60, z=3)])
+    wdg.setValue(pos_seq)
+
+    # then enable and set an absolute grid plan
+    abs_grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
+    wdg.tab_wdg.setChecked(wdg.grid_plan, True)
+    wdg.grid_plan.setValue(abs_grid)
+
+    result = wdg.value()
+
+    # x/y should be cleared because the global grid is absolute
+    for pos in result.stage_positions:
+        assert pos.x is None
+        assert pos.y is None
+
+
 def test_mda_popup_with_polygon(qtbot: QtBot) -> None:
     polygon = useq.GridFromPolygon(
         vertices=[(-10, 0), (12, -5), (10, 20), (0, 10)],

--- a/tests/useq_widgets/test_useq_widgets.py
+++ b/tests/useq_widgets/test_useq_widgets.py
@@ -800,19 +800,6 @@ def test_has_absolute_grid_helper(qtbot: QtBot) -> None:
     )
 
 
-def test_first_grid_xy_helper() -> None:
-    """Test the _first_grid_xy static method."""
-    grid = useq.GridFromEdges(top=10, bottom=0, left=0, right=10)
-    result = PositionTable._first_grid_xy(grid)
-    assert result is not None
-    first = next(iter(grid))
-    assert result == (first.x, first.y)
-
-    # invalid input returns None
-    assert PositionTable._first_grid_xy(None) is None
-    assert PositionTable._first_grid_xy("not a grid") is None
-
-
 def test_mda_value_clears_xy_for_absolute_grid(qtbot: QtBot) -> None:
     """Test that MDATabs.value() clears x/y when a global absolute grid is used."""
     wdg = MDASequenceWidget()


### PR DESCRIPTION
@tlambert03 what do you think of this behavior? We should ask Claude to probably have a look and refactor a bit the code but I think the general logic is what we need.

**Summary of the changes**:
- Adds `FloatColumn` nullable support for proper `None` handling in x/y fields.
- Clears x/y on positions when an absolute grid is used: absolute grids define their own coordinates, so position x/y values are meaningless and caused useq validation warnings.
- Disables x/y editing for positions with absolute sub-sequence grids: shows the grid's first position and prevents manual edits.
- Disables absolute grid modes when stage positions are present (since does not make sense to have multiple position with defined xy and a global grid plan)
- Moves global absolute grid into per-position sub-sequences: when `setValue()` loads a sequence with both positions and an absolute grid, the grid is automatically distributed into each position's sub-sequence and the global grid tab is unchecked.
- Prevents unchecking the positions tab when a global absolute grid is active.

---

This `MDASequence`:
```py
seq = useq.MDASequence(
    stage_positions=[useq.Position(z=3)],
    grid_plan=useq.GridFromEdges(top=0.5, bottom=-1, right=1, left=0),
)
```
 when passed to the `MDAWidget.setValue()` is internally converted to this one:
```py
seq = useq.MDASequence(
    stage_positions=[
        useq.Position(
            z=3,
            sequence=useq.MDASequence(
                grid_plan=useq.GridFromEdges(top=0.5, bottom=-1, right=1, left=0),
            ),
        ),
    ],
)
```

---

Couple of videos to show the main implementation:

https://github.com/user-attachments/assets/3f68e10a-0844-426b-9890-c13d341d561f

https://github.com/user-attachments/assets/5acc7f8d-861c-483b-ba4b-77860bb1aadf





